### PR TITLE
fix(committee): increase image size for committe images

### DIFF
--- a/src/constants/committees.ts
+++ b/src/constants/committees.ts
@@ -10,6 +10,6 @@ export const MIN_ORDER_NUMBER = 0;
 
 export const MAX_ORDER_NUMBER = 99;
 
-export const COMMITTEE_IMAGE_SIZE = 300;
+export const COMMITTEE_IMAGE_SIZE = 500;
 
 export const COMMITTEE_IMAGE_QUALITY = 95;


### PR DESCRIPTION
Skapade inget trello kort men kolla prod så ser man att ex zeniths bilder har väldigt låg upplösning. Denna PR fixar detta (kräver dock att de laddar upp nya bilder)